### PR TITLE
Platform support to print Z9100 and S6100 sensors

### DIFF
--- a/debian/platform-modules-s6100.install
+++ b/debian/platform-modules-s6100.install
@@ -1,3 +1,4 @@
 s6100/scripts/io_rd_wr.py usr/local/bin
 s6100/scripts/iom_power_*.sh usr/local/bin
 s6100/scripts/s6100_platform_init.sh usr/local/bin
+s6100/scripts/platform_sensors.py usr/local/bin

--- a/debian/platform-modules-z9100.install
+++ b/debian/platform-modules-z9100.install
@@ -1,3 +1,4 @@
 z9100/scripts/check_qsfp.sh usr/local/bin
 z9100/scripts/z9100_platform_init.sh usr/local/bin
+z9100/scripts/platform_sensors.py usr/local/bin
 z9100/cfg/z9100-modules.conf etc/modules-load.d

--- a/s6100/modules/dell_s6100_lpc.c
+++ b/s6100/modules/dell_s6100_lpc.c
@@ -1,6 +1,7 @@
 
 #include <linux/module.h>
 #include <linux/kernel.h>
+#include <linux/spinlock.h>
 //for platform drivers....
 #include <linux/platform_device.h>
 
@@ -20,54 +21,104 @@
 #define SMF_MB_READ_DATA  0x212
 #define SMF_MB_WRITE_DATA  0x213
 
-/* SMF MB Registers */
+/* System LED Registers */
 
-#define MAX_NUM_TEMP_SENSORS 0x0013
-#define MAX_NUM_PSU          0x0231
-#define PSU1_STATUS          0x0237
-#define PSU2_STATUS          0x0270
 #define SYS_STATUS_LED       0x130
-#define TOTAL_PWR            0x0232
-#define MAX_PSU1_PWR         0x0234
-#define MAX_PSU2_PWR         0x026D
+
+/* IOM presence */
+
+#define IO_MODULE_STATUS   0x0310
+#define IO_MODULE_PRESENCE 0x0311
 
 /* SMF temp sensors */
 
-#define TEMP_SENS_1  0x0014
-#define TEMP_SENS_2  0x0016
-#define TEMP_SENS_3  0x0018
-#define TEMP_SENS_4  0x001A
-#define TEMP_SENS_5  0x001C
-#define TEMP_SENS_6  0x001E
-#define TEMP_SENS_7  0x0020
-#define TEMP_SENS_8  0x0022
-#define TEMP_SENS_9  0x0024
-#define TEMP_SENS_10 0x0026
-#define TEMP_SENS_11 0x0028
+#define S6100_MAX_TEMP_SENSORS 11
+
+#define MAX_NUM_TEMP_SENSORS 0x0013
+
+#define TEMP_1_SENS  0x0014
+#define TEMP_2_SENS  0x0016
+#define TEMP_3_SENS  0x0018
+#define TEMP_4_SENS  0x001A
+#define TEMP_5_SENS  0x001C
+#define TEMP_6_SENS  0x001E
+#define TEMP_7_SENS  0x0020
+#define TEMP_8_SENS  0x0022
+#define TEMP_9_SENS  0x0024
+#define TEMP_10_SENS  0x0026
+#define TEMP_11_SENS  0x0028
 
 /* FAN Tray */
-#define MAX_NUM_FAN_TRAYS    0x00F0
-#define MAX_NUM_FAN_PER_TRAY 0x00F1
-#define FAN_TRAY_PRES        0x0113
+
+#define S6100_MAX_NUM_FAN_TRAYS 4
+
+#define MAX_NUM_FAN_TRAYS     0x00F0
+#define MAX_NUM_FANS_PER_TRAY 0x00F1
+#define FAN_TRAY_PRESENCE     0x0113
+#define FAN_STATUS_GROUP_A    0x0114
+#define FAN_STATUS_GROUP_B    0x0115
+#define FAN_TRAY_AIRFLOW      0x0116
 
 #define FAN_TRAY_1_SPEED  0x00F3
 #define FAN_TRAY_2_SPEED  0x00F7
 #define FAN_TRAY_3_SPEED  0x00FB
 #define FAN_TRAY_4_SPEED  0x00FF
 
+/* PSUs */
+
+#define S6100_MAX_NUM_PSUS 2
+
+#define MAX_NUM_PSUS           0x0231
+#define CURRENT_TOTAL_POWER    0x0232
+
+// PSU1
+#define PSU_1_MAX_POWER        0x0234
+#define PSU_1_FUNCTION_SUPPORT 0x0236
+#define PSU_1_STATUS           0x0237
+#define PSU_1_TEMPERATURE      0x0239
+#define PSU_1_FAN_SPEED        0x023B
+#define PSU_1_FAN_STATUS       0x023D
+#define PSU_1_INPUT_VOLTAGE    0x023E
+#define PSU_1_OUTPUT_VOLTAGE   0x0240
+#define PSU_1_INPUT_CURRENT    0x0242
+#define PSU_1_OUTPUT_CURRENT   0x0244
+#define PSU_1_INPUT_POWER      0x0246
+#define PSU_1_OUTPUT_POWER     0x0248
+
+// PSU2
+#define PSU_2_MAX_POWER        0x026D
+#define PSU_2_FUNCTION_SUPPORT 0x026F
+#define PSU_2_STATUS           0x0270
+#define PSU_2_TEMPERATURE      0x0272
+#define PSU_2_FAN_SPEED        0x0274
+#define PSU_2_FAN_STATUS       0x0276
+#define PSU_2_INPUT_VOLTAGE    0x0277
+#define PSU_2_OUTPUT_VOLTAGE   0x0279
+#define PSU_2_INPUT_CURRENT    0x027B
+#define PSU_2_OUTPUT_CURRENT   0x027D
+#define PSU_2_INPUT_POWER      0x027F
+#define PSU_2_OUTPUT_POWER     0x0281
+
+/* Optics Table */
+#define MAX_NUM_OPTICS 0x410
 
 unsigned long  *mmio;
 
+spinlock_t smf_slock;
+
 /* SMF read function */
 
-static int sfm_read_byte(int addr)
+static uint8_t sfm_read_byte(int addr)
 {
-    /* lock is acquired by user before invoking this */
-    //printk(KERN_ERR " Addr HI %x ",((addr >> 8) & 0xff));
+    u8 retval;
+
+    spin_lock(&smf_slock);
     outb(((addr >> 8) & 0xff),SMF_MB_ADDR_HI);
-    //printk(KERN_ERR "Addr LO %x \n",(addr & 0xff));
     outb((addr & 0xff),SMF_MB_ADDR_LO);
-    return inb(SMF_MB_READ_DATA);
+    retval = inb(SMF_MB_READ_DATA);
+    spin_unlock(&smf_slock);
+
+    return retval;
 }
 
 /* change ver to info */
@@ -77,10 +128,7 @@ static int sfm_read_two_byte(u16 offset)
 
     u8 low_byte=0,high_byte=0;
     high_byte = sfm_read_byte(offset);
-    //printk(KERN_ERR " low_byte %x\n",high_byte);
     low_byte =  sfm_read_byte(offset+1);
-    //printk(KERN_ERR " low_byte %x\n",low_byte);
-    //printk ( KERN_ERR " Value %x",((high_byte <<8) | ( low_byte)));
 
     return ((high_byte <<8) | ( low_byte));
 
@@ -92,7 +140,7 @@ static struct resource dell_s6100_lpc_resources[] = {
     {
         .start          = RESOURCE1_START_ADDRESS,
         .end            = RESOURCE1_END_ADDRESS,
-        .flags          = IORESOURCE_MEM,
+        .flags          = IORESOURCE_IO,
     },
 };
 
@@ -112,17 +160,22 @@ static struct platform_device dell_s6100_lpc_dev = {
     }
 };
 
-
-
 /* change ver to info */
 static ssize_t get_smfver(struct device *dev, struct device_attribute *devattr, char *buf)
 {
+    printk( KERN_ALERT " Dev attributed fetched:%s\n", devattr->attr.name);
     return sprintf(buf, "%x\n",inb(SMF_REG_VERSION));
 }
 
 static ssize_t get_sys_led(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     return sprintf(buf,"%x\n", inb(SYS_STATUS_LED));
+}
+
+static ssize_t get_max_num_optics(struct device *dev, struct device_attribute *devattr,
+		char *buf)
+{
+    return sprintf(buf,"%d\n",sfm_read_byte(MAX_NUM_OPTICS));
 }
 
 static ssize_t set_sys_led(struct device *dev, struct device_attribute *devattr, const char *buf, 
@@ -140,152 +193,258 @@ static ssize_t set_sys_led(struct device *dev, struct device_attribute *devattr,
     return count;
 }
 
-
 static ssize_t get_fan_tray_presence(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%x\n", sfm_read_byte(FAN_TRAY_PRES));
+    return sprintf(buf,"%02hhx\n", ~sfm_read_byte(FAN_TRAY_PRESENCE));
 }
 
 static ssize_t get_max_num_temp_sensors(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%x\n", sfm_read_byte(MAX_NUM_TEMP_SENSORS));
+    return sprintf(buf,"%hhd\n", sfm_read_byte(MAX_NUM_TEMP_SENSORS));
 }
 
 static ssize_t get_max_num_fan_trays(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%x\n", sfm_read_byte(MAX_NUM_FAN_TRAYS));
+    return sprintf(buf,"%hhx\n", sfm_read_byte(MAX_NUM_FAN_TRAYS));
 }
 
 static ssize_t get_max_num_fans_per_tray(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%x\n", sfm_read_byte(MAX_NUM_FAN_PER_TRAY));
+    return sprintf(buf,"%x\n", sfm_read_byte(MAX_NUM_FANS_PER_TRAY));
 }
 
-static ssize_t get_max_num_psu(struct device *dev, struct device_attribute *devattr, char *buf)
+static ssize_t get_fan_status_region_a(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%x\n", sfm_read_byte(MAX_NUM_PSU));
+    return sprintf(buf,"%x\n", sfm_read_byte(FAN_STATUS_GROUP_A));
 }
 
-static ssize_t get_psu_total_pwr(struct device *dev, struct device_attribute *devattr, char *buf)
+static ssize_t get_fan_status_region_b(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TOTAL_PWR)/10));
+    return sprintf(buf,"%x\n", sfm_read_byte(FAN_STATUS_GROUP_B));
 }
 
-static ssize_t get_psu1_max_pwr(struct device *dev, struct device_attribute *devattr, char *buf)
+static ssize_t get_fan_tray_airflow(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(MAX_PSU1_PWR)/10));
+    return sprintf(buf,"%x\n", sfm_read_byte(FAN_TRAY_AIRFLOW));
 }
 
-static ssize_t get_psu2_max_pwr(struct device *dev, struct device_attribute *devattr, char *buf)
+static ssize_t get_max_num_psus(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(MAX_PSU2_PWR)/10));
+    return sprintf(buf,"%x\n", sfm_read_byte(MAX_NUM_PSUS));
 }
 
-static ssize_t get_psu1_status(struct device *dev, struct device_attribute *devattr, char *buf)
+static ssize_t get_psu_total_power(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%x\n", sfm_read_byte(PSU1_STATUS));
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(CURRENT_TOTAL_POWER)/10));
 }
 
-static ssize_t get_psu2_status(struct device *dev, struct device_attribute *devattr, char *buf)
+static ssize_t get_iom_status(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf,"%x\n", sfm_read_byte(PSU2_STATUS));
+    return sprintf(buf,"%x\n", sfm_read_byte(IO_MODULE_STATUS));
 }
+
+
+static ssize_t get_iom_presence(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    return sprintf(buf,"%x\n", sfm_read_byte(IO_MODULE_PRESENCE));
+}
+
 
 /* Temp Sensors */
 
-static ssize_t get_temp_sensor1(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_1)/10));
-}
-static ssize_t get_temp_sensor2(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_2)/10));
-}
-static ssize_t get_temp_sensor3(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_3)/10));
-}
-static ssize_t get_temp_sensor4(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_4)/10));
-}
-static ssize_t get_temp_sensor5(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_5)/10));
-}
-static ssize_t get_temp_sensor6(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_6)/10));
-}
-static ssize_t get_temp_sensor7(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_7)/10));
-}
-static ssize_t get_temp_sensor8(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_8)/10));
-}
-static ssize_t get_temp_sensor9(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_9)/10));
-}
-static ssize_t get_temp_sensor10(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_10)/10));
-}
-static ssize_t get_temp_sensor11(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_SENS_11)/10));
+#define GET_TEMP_SENSOR(index) \
+static ssize_t get_temp_##index##_sensor(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(TEMP_##index##_SENS)/10)); \
 }
 
-static ssize_t get_fan_tray_1_speed(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", sfm_read_two_byte(FAN_TRAY_1_SPEED));
+GET_TEMP_SENSOR(1)
+GET_TEMP_SENSOR(2)
+GET_TEMP_SENSOR(3)
+GET_TEMP_SENSOR(4)
+GET_TEMP_SENSOR(5)
+GET_TEMP_SENSOR(6)
+GET_TEMP_SENSOR(7)
+GET_TEMP_SENSOR(8)
+GET_TEMP_SENSOR(9)
+GET_TEMP_SENSOR(10)
+GET_TEMP_SENSOR(11)
+
+/* FAN Trays */
+
+#define GET_FAN_TRAY_SPEED(index) \
+static ssize_t get_fan_tray_##index##_speed(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", sfm_read_two_byte(FAN_TRAY_##index##_SPEED)); \
 }
-static ssize_t get_fan_tray_2_speed(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", sfm_read_two_byte(FAN_TRAY_2_SPEED));
+
+GET_FAN_TRAY_SPEED(1)
+GET_FAN_TRAY_SPEED(2)
+GET_FAN_TRAY_SPEED(3)
+GET_FAN_TRAY_SPEED(4)
+
+/* PSUs */
+
+#define GET_PSU_MAX_POWER(index) \
+static ssize_t get_psu_##index##_max_power(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_MAX_POWER)/10)); \
 }
-static ssize_t get_fan_tray_3_speed(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", sfm_read_two_byte(FAN_TRAY_3_SPEED));
+
+#define GET_PSU_FUNCTION_SUPPORT(index) \
+static ssize_t get_psu_##index##_function_support(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_byte(PSU_##index##_FUNCTION_SUPPORT))); \
 }
-static ssize_t get_fan_tray_4_speed(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    return sprintf(buf,"%d\n", sfm_read_two_byte(FAN_TRAY_4_SPEED));
+
+#define GET_PSU_STATUS(index) \
+static ssize_t get_psu_##index##_status(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_byte(PSU_##index##_STATUS))); \
 }
+
+#define GET_PSU_TEMPERATURE(index) \
+static ssize_t get_psu_##index##_temperature(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_TEMPERATURE)/10)); \
+}
+
+#define GET_PSU_FAN_SPEED(index) \
+static ssize_t get_psu_##index##_fan_speed(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_FAN_SPEED))); \
+}
+
+#define GET_PSU_FAN_STATUS(index) \
+static ssize_t get_psu_##index##_fan_status(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_byte(PSU_##index##_FAN_STATUS))); \
+}
+
+#define GET_PSU_INPUT_VOLTAGE(index) \
+static ssize_t get_psu_##index##_input_voltage(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_INPUT_VOLTAGE))); \
+}
+
+#define GET_PSU_OUTPUT_VOLTAGE(index) \
+static ssize_t get_psu_##index##_output_voltage(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_OUTPUT_VOLTAGE))); \
+}
+
+#define GET_PSU_INPUT_CURRENT(index) \
+static ssize_t get_psu_##index##_input_current(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_INPUT_CURRENT))); \
+}
+
+#define GET_PSU_OUTPUT_CURRENT(index) \
+static ssize_t get_psu_##index##_output_current(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_OUTPUT_CURRENT))); \
+}
+
+#define GET_PSU_INPUT_POWER(index) \
+static ssize_t get_psu_##index##_input_power(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_INPUT_POWER))); \
+}
+
+#define GET_PSU_OUTPUT_POWER(index) \
+static ssize_t get_psu_##index##_output_power(struct device *dev, struct device_attribute *devattr, char *buf) \
+{ \
+    return sprintf(buf,"%d\n", (sfm_read_two_byte(PSU_##index##_OUTPUT_POWER))); \
+}
+
+GET_PSU_MAX_POWER(1)
+GET_PSU_FUNCTION_SUPPORT(1)
+GET_PSU_STATUS(1)
+GET_PSU_TEMPERATURE(1)
+GET_PSU_FAN_SPEED(1)
+GET_PSU_FAN_STATUS(1)
+GET_PSU_INPUT_VOLTAGE(1)
+GET_PSU_OUTPUT_VOLTAGE(1)
+GET_PSU_INPUT_CURRENT(1)
+GET_PSU_OUTPUT_CURRENT(1)
+GET_PSU_INPUT_POWER(1)
+GET_PSU_OUTPUT_POWER(1)
+
+GET_PSU_MAX_POWER(2)
+GET_PSU_FUNCTION_SUPPORT(2)
+GET_PSU_STATUS(2)
+GET_PSU_TEMPERATURE(2)
+GET_PSU_FAN_SPEED(2)
+GET_PSU_FAN_STATUS(2)
+GET_PSU_INPUT_VOLTAGE(2)
+GET_PSU_OUTPUT_VOLTAGE(2)
+GET_PSU_INPUT_CURRENT(2)
+GET_PSU_OUTPUT_CURRENT(2)
+GET_PSU_INPUT_POWER(2)
+GET_PSU_OUTPUT_POWER(2)
+
+// Attribute declarations
 
 static DEVICE_ATTR(smf_ver,S_IRUGO,get_smfver, NULL);
+static DEVICE_ATTR(sys_led,S_IRUGO | S_IWUSR,get_sys_led,set_sys_led);
+static DEVICE_ATTR(iom_status,S_IRUGO | S_IWUSR,get_iom_status,NULL);
+static DEVICE_ATTR(iom_presence,S_IRUGO | S_IWUSR,get_iom_presence,NULL);
+
 static DEVICE_ATTR(max_num_temp_sensors,S_IRUGO,get_max_num_temp_sensors, NULL);
+static DEVICE_ATTR(temp_sensor_1,S_IRUGO,get_temp_1_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_2,S_IRUGO,get_temp_2_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_3,S_IRUGO,get_temp_3_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_4,S_IRUGO,get_temp_4_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_5,S_IRUGO,get_temp_5_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_6,S_IRUGO,get_temp_6_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_7,S_IRUGO,get_temp_7_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_8,S_IRUGO,get_temp_8_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_9,S_IRUGO,get_temp_9_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_10,S_IRUGO,get_temp_10_sensor, NULL);
+static DEVICE_ATTR(temp_sensor_11,S_IRUGO,get_temp_11_sensor, NULL);
+
 static DEVICE_ATTR(max_num_fan_trays,S_IRUGO,get_max_num_fan_trays, NULL);
 static DEVICE_ATTR(max_num_fans_per_tray,S_IRUGO,get_max_num_fans_per_tray, NULL);
 static DEVICE_ATTR(fan_tray_presence,S_IRUGO,get_fan_tray_presence, NULL);
-static DEVICE_ATTR(max_num_psu,S_IRUGO,get_max_num_psu, NULL);
-static DEVICE_ATTR(psu1_status,S_IRUGO,get_psu1_status, NULL);
-static DEVICE_ATTR(psu2_status,S_IRUGO,get_psu2_status, NULL);
-static DEVICE_ATTR(psu_total_pwr,S_IRUGO,get_psu_total_pwr, NULL);
-static DEVICE_ATTR(psu1_max_pwr,S_IRUGO,get_psu1_max_pwr, NULL);
-static DEVICE_ATTR(psu2_max_pwr,S_IRUGO,get_psu2_max_pwr, NULL);
-static DEVICE_ATTR(sys_led,S_IRUGO | S_IWUSR,get_sys_led,set_sys_led);
-
-
-static DEVICE_ATTR(temp_sensor_1,S_IRUGO,get_temp_sensor1, NULL);
-static DEVICE_ATTR(temp_sensor_2,S_IRUGO,get_temp_sensor2, NULL);
-static DEVICE_ATTR(temp_sensor_3,S_IRUGO,get_temp_sensor3, NULL);
-static DEVICE_ATTR(temp_sensor_4,S_IRUGO,get_temp_sensor4, NULL);
-static DEVICE_ATTR(temp_sensor_5,S_IRUGO,get_temp_sensor5, NULL);
-static DEVICE_ATTR(temp_sensor_6,S_IRUGO,get_temp_sensor6, NULL);
-static DEVICE_ATTR(temp_sensor_7,S_IRUGO,get_temp_sensor7, NULL);
-static DEVICE_ATTR(temp_sensor_8,S_IRUGO,get_temp_sensor8, NULL);
-static DEVICE_ATTR(temp_sensor_9,S_IRUGO,get_temp_sensor9, NULL);
-static DEVICE_ATTR(temp_sensor_10,S_IRUGO,get_temp_sensor10, NULL);
-static DEVICE_ATTR(temp_sensor_11,S_IRUGO,get_temp_sensor11, NULL);
+static DEVICE_ATTR(fan_status_region_a,S_IRUGO,get_fan_status_region_a, NULL);
+static DEVICE_ATTR(fan_status_region_b,S_IRUGO,get_fan_status_region_b, NULL);
+static DEVICE_ATTR(fan_tray_airflow,S_IRUGO,get_fan_tray_airflow, NULL);
 
 static DEVICE_ATTR(fan_tray_1_speed,S_IRUGO,get_fan_tray_1_speed, NULL);
 static DEVICE_ATTR(fan_tray_2_speed,S_IRUGO,get_fan_tray_2_speed, NULL);
 static DEVICE_ATTR(fan_tray_3_speed,S_IRUGO,get_fan_tray_3_speed, NULL);
 static DEVICE_ATTR(fan_tray_4_speed,S_IRUGO,get_fan_tray_4_speed, NULL);
 
+static DEVICE_ATTR(max_num_psus,S_IRUGO,get_max_num_psus, NULL);
+static DEVICE_ATTR(psu_total_power,S_IRUGO,get_psu_total_power, NULL);
+
+static DEVICE_ATTR(psu_1_max_power,S_IRUGO,get_psu_1_max_power, NULL);
+static DEVICE_ATTR(psu_1_function_support,S_IRUGO,get_psu_1_function_support, NULL);
+static DEVICE_ATTR(psu_1_status,S_IRUGO,get_psu_1_status, NULL);
+static DEVICE_ATTR(psu_1_temperature,S_IRUGO,get_psu_1_temperature, NULL);
+static DEVICE_ATTR(psu_1_fan_speed,S_IRUGO,get_psu_1_fan_speed, NULL);
+static DEVICE_ATTR(psu_1_fan_status,S_IRUGO,get_psu_1_fan_status, NULL);
+static DEVICE_ATTR(psu_1_input_voltage,S_IRUGO,get_psu_1_input_voltage, NULL);
+static DEVICE_ATTR(psu_1_output_voltage,S_IRUGO,get_psu_1_output_voltage, NULL);
+static DEVICE_ATTR(psu_1_input_current,S_IRUGO,get_psu_1_input_current, NULL);
+static DEVICE_ATTR(psu_1_output_current,S_IRUGO,get_psu_1_output_current, NULL);
+static DEVICE_ATTR(psu_1_input_power,S_IRUGO,get_psu_1_input_power, NULL);
+static DEVICE_ATTR(psu_1_output_power,S_IRUGO,get_psu_1_output_power, NULL);
+
+static DEVICE_ATTR(psu_2_max_power,S_IRUGO,get_psu_2_max_power, NULL);
+static DEVICE_ATTR(psu_2_function_support,S_IRUGO,get_psu_2_function_support, NULL);
+static DEVICE_ATTR(psu_2_status,S_IRUGO,get_psu_2_status, NULL);
+static DEVICE_ATTR(psu_2_temperature,S_IRUGO,get_psu_2_temperature, NULL);
+static DEVICE_ATTR(psu_2_fan_speed,S_IRUGO,get_psu_2_fan_speed, NULL);
+static DEVICE_ATTR(psu_2_fan_status,S_IRUGO,get_psu_2_fan_status, NULL);
+static DEVICE_ATTR(psu_2_input_voltage,S_IRUGO,get_psu_2_input_voltage, NULL);
+static DEVICE_ATTR(psu_2_output_voltage,S_IRUGO,get_psu_2_output_voltage, NULL);
+static DEVICE_ATTR(psu_2_input_current,S_IRUGO,get_psu_2_input_current, NULL);
+static DEVICE_ATTR(psu_2_output_current,S_IRUGO,get_psu_2_output_current, NULL);
+static DEVICE_ATTR(psu_2_input_power,S_IRUGO,get_psu_2_input_power, NULL);
+static DEVICE_ATTR(psu_2_output_power,S_IRUGO,get_psu_2_output_power, NULL);
+
+static DEVICE_ATTR(max_num_optics,S_IRUGO | S_IWUSR,get_max_num_optics,NULL);
 
 static struct attribute *s6100_lpc_attrs[] = {
     &dev_attr_smf_ver.attr,
@@ -293,13 +452,18 @@ static struct attribute *s6100_lpc_attrs[] = {
     &dev_attr_max_num_fan_trays.attr,
     &dev_attr_max_num_fans_per_tray.attr,
     &dev_attr_fan_tray_presence.attr,
-    &dev_attr_max_num_psu.attr,
-    &dev_attr_psu1_status.attr,
-    &dev_attr_psu2_status.attr,
-    &dev_attr_psu_total_pwr.attr,
-    &dev_attr_psu1_max_pwr.attr,
-    &dev_attr_psu2_max_pwr.attr,
+    &dev_attr_fan_status_region_a.attr,
+    &dev_attr_fan_status_region_b.attr,
+    &dev_attr_fan_tray_airflow.attr,
+    &dev_attr_max_num_psus.attr,
     &dev_attr_sys_led.attr,
+    &dev_attr_max_num_optics.attr,
+    &dev_attr_iom_status.attr,
+    &dev_attr_iom_presence.attr,
+    NULL,
+};
+
+static struct attribute *s6100_temperature_attrs[] = {
     &dev_attr_temp_sensor_1.attr,
     &dev_attr_temp_sensor_2.attr,
     &dev_attr_temp_sensor_3.attr,
@@ -311,6 +475,10 @@ static struct attribute *s6100_lpc_attrs[] = {
     &dev_attr_temp_sensor_9.attr,
     &dev_attr_temp_sensor_10.attr,
     &dev_attr_temp_sensor_11.attr,
+    NULL,
+};
+
+static struct attribute *s6100_fantray_attrs[] = {
     &dev_attr_fan_tray_1_speed.attr,
     &dev_attr_fan_tray_2_speed.attr,
     &dev_attr_fan_tray_3_speed.attr,
@@ -318,8 +486,48 @@ static struct attribute *s6100_lpc_attrs[] = {
     NULL,
 };
 
+static struct attribute *s6100_psu_attrs[] = {
+    &dev_attr_psu_total_power.attr,
+    &dev_attr_psu_1_max_power.attr,
+    &dev_attr_psu_1_function_support.attr,
+    &dev_attr_psu_1_status.attr,
+    &dev_attr_psu_1_temperature.attr,
+    &dev_attr_psu_1_fan_speed.attr,
+    &dev_attr_psu_1_fan_status.attr,
+    &dev_attr_psu_1_input_voltage.attr,
+    &dev_attr_psu_1_output_voltage.attr,
+    &dev_attr_psu_1_input_current.attr,
+    &dev_attr_psu_1_output_current.attr,
+    &dev_attr_psu_1_input_power.attr,
+    &dev_attr_psu_1_output_power.attr,
+    &dev_attr_psu_2_max_power.attr,
+    &dev_attr_psu_2_function_support.attr,
+    &dev_attr_psu_2_status.attr,
+    &dev_attr_psu_2_temperature.attr,
+    &dev_attr_psu_2_fan_speed.attr,
+    &dev_attr_psu_2_fan_status.attr,
+    &dev_attr_psu_2_input_voltage.attr,
+    &dev_attr_psu_2_output_voltage.attr,
+    &dev_attr_psu_2_input_current.attr,
+    &dev_attr_psu_2_output_current.attr,
+    &dev_attr_psu_2_input_power.attr,
+    &dev_attr_psu_2_output_power.attr,
+    NULL,
+};
+
 static struct attribute_group s6100_lpc_attr_grp = {
     .attrs = s6100_lpc_attrs,
+};
+static struct attribute_group s6100_temperature_attr_grp = {
+    .attrs = s6100_temperature_attrs,
+};
+
+static struct attribute_group s6100_fantray_attr_grp = {
+    .attrs = s6100_fantray_attrs,
+};
+
+static struct attribute_group s6100_psu_attr_grp = {
+    .attrs = s6100_psu_attrs,
 };
 
 
@@ -328,29 +536,46 @@ static int dell_s6100_lpc_drv_probe(struct platform_device *pdev)
     struct resource *res;
     int ret =0;
 
-    res = platform_get_resource(pdev, IORESOURCE_MEM,0);
+    res = platform_get_resource(pdev, IORESOURCE_IO,0);
     if (unlikely(!res)) {
         printk(KERN_ERR " Specified Resource Not Available... 1\n");
         return -1;
     }
 
-    printk(KERN_INFO "Start:%x,  End:%x Size:%d\n", (unsigned long)res->start, 
-            (unsigned long)res->end, resource_size(res));
+    printk(KERN_INFO "Start:%lx,  End:%lx Size:%ld\n", (unsigned long)res->start, 
+            (unsigned long)res->end, (unsigned long)resource_size(res));
 
     //Converting the physical Address to virtual for using in driver 
     mmio = ioremap(res->start, resource_size(res));
     if (unlikely(!mmio)) {
         printk(KERN_ERR " (cannot map IO)\n");
-        return;
+        return -1;
     }
 
-    printk(KERN_INFO "\n Registering Sysfs :%d\n");
+    printk(KERN_INFO "\n Registering Sysfs \n");
     /* Register sysfs hooks */
     ret = sysfs_create_group(&pdev->dev.kobj, &s6100_lpc_attr_grp);
     if (ret) {
         printk(KERN_ERR "Cannot create sysfs\n");
     }
 
+    printk(KERN_ERR "Attemting to create temperature attributes");
+    ret = sysfs_create_group(&pdev->dev.kobj, &s6100_temperature_attr_grp);
+    if (ret) {
+        printk(KERN_ERR "Cannot create temperature sysfs\n");
+    }
+
+    printk(KERN_ERR "Attemting to create Fantray attributes");
+    ret = sysfs_create_group(&pdev->dev.kobj, &s6100_fantray_attr_grp);
+    if (ret) {
+        printk(KERN_ERR "Cannot create fantray sysfs\n");
+    }
+
+    printk(KERN_ERR "Attemting to create PSU attributes");
+    ret = sysfs_create_group(&pdev->dev.kobj, &s6100_psu_attr_grp);
+    if (ret) {
+        printk(KERN_ERR "Cannot create psu sysfs\n");
+    }
     return 0;  
 }
 
@@ -372,6 +597,8 @@ static struct platform_driver dell_s6100_lpc_drv = {
 
 int dell_s6100_lpc_init(void)
 {
+    spin_lock_init(&smf_slock);
+
     platform_device_register(&dell_s6100_lpc_dev);
     platform_driver_register(&dell_s6100_lpc_drv);
     return 0;

--- a/s6100/scripts/platform_sensors.py
+++ b/s6100/scripts/platform_sensors.py
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+
+# On S6100, the Platform Management Controller runs the
+# thermal algorithm. It provides a mailbox for the Host
+# to query relevant thermals. The dell_mailbox module
+# provides the sysfs support for the following objects:
+#   * onboard temperature sensors
+#   * FAN trays
+#   * PSU
+
+import os
+import sys
+import logging
+
+S6100_MAX_FAN_TRAYS = 4
+S6100_MAX_PSUS = 2
+S6100_MAX_IOMS = 4
+
+MAILBOX_DIR="/sys/devices/platform/dell_s6100_lpc"
+
+iom_status_list = [ ]
+
+#Get a mailbox register
+def get_pmc_register(reg_name):
+    retval = 'ERR'
+    mb_reg_file = MAILBOX_DIR+'/'+reg_name
+    
+    if ( not os.path.isfile(mb_reg_file)):
+        print mb_reg_file,  'not found !'
+        return retval
+
+    try:
+        with open(mb_reg_file, 'r') as fd:
+            retval = fd.read()
+    except Exception as error:
+        logging.error("Unable to open ", mb_reg_file , "file !")
+
+    retval = retval.rstrip('\r\n')
+    return retval;
+
+logging.basicConfig(level=logging.DEBUG)
+
+if (os.path.isdir(MAILBOX_DIR)):
+    print 'dell-s6100-lpc'
+    print 'Adapter: S6100 Platform Management Controller'
+else:
+    logging.error('S6100 Platform Management Controller module not loaded !')
+    sys.exit(0)
+
+#Print the information for temperature sensors
+def print_temperature_sensors():
+    print("Onboard Temperature Sensors:")
+    print '  CPU:                            ' , get_pmc_register('temp_sensor_1') , 'C'
+    print '  BCM56960 (PSU side):            ' , get_pmc_register('temp_sensor_2') , 'C'
+    print '  System Outlet 1 (switch board): ' , get_pmc_register('temp_sensor_3') , 'C'
+    print '  BCM56960 (IO side):             ' , get_pmc_register('temp_sensor_4') , 'C'
+    print '  System Outlet 2 (CPU board):    ' , get_pmc_register('temp_sensor_9') , 'C'
+    print '  System Inlet Left (IO side):    ' , get_pmc_register('temp_sensor_10') , 'C'
+    print '  System Inlet Right (IO side):   ' , get_pmc_register('temp_sensor_11') , 'C'
+
+    iom_status = get_pmc_register('iom_status')
+    iom_status = int(iom_status, 16)
+
+    iom_presence = get_pmc_register('iom_presence')
+
+    if (iom_presence != 'ERR'):
+        iom_presence = int(iom_presence, 16)
+
+        # IOM presence : 0 => IOM present
+        # Temperature sensors 5..8 correspond to IOM 1..4
+        for iom in range(0,S6100_MAX_IOMS):
+            if (~iom_presence & (1<<iom)):
+                iom_sensor_indx = iom + 5
+                print '  IOM '+ str(iom + 1) +':\t\t\t  ' , get_pmc_register('temp_sensor_'+str(iom_sensor_indx)) , 'C'
+
+                # Save the IOM Status for later use
+                if (~iom_status & (1<<iom)):
+                    iom_status_list.append('ON')
+                else:
+                    iom_status_list.append('OFF')
+            else:
+                iom_status_list.append('Not present')
+                print '  IOM '+ str(iom + 1) +':\t\t\t  ', 'Not present'
+    else:
+        logging.error('Unable to check IOM presence')
+
+print_temperature_sensors()
+
+#Print the information for 1 Fan Tray
+def print_fan_tray(tray):
+
+    Fan_Status = ['Normal', 'Abnormal']
+    Airflow_Direction = ['B2F', 'F2B']
+
+    print '  Fan Tray ' + str(tray) + ':'
+    print '    Speed:    ' , get_pmc_register('fan_tray_'+str(tray)+'_speed') , 'RPM'
+
+    # Each fan tray has 2 fans. Each region register is 8 bits and has
+    # information for 4 trays. The region_b has information about the first
+    # 4 trays.
+    if ( tray <= 4 ):
+        fan_status_region = int(get_pmc_register('fan_status_region_b'), 16)
+    else:
+        fan_status_region = int(get_pmc_register('fan_status_region_a'), 16)
+
+    fan1_shift = (tray-1)*2
+    fan1_status = ( fan_status_region & (1<<fan1_shift) ) >> fan1_shift
+    fan2_shift = ((tray-1)*2) + 1
+    fan2_status = ( fan_status_region & (1<<fan2_shift) ) >> fan2_shift
+
+    print '    Fan 1:    ', Fan_Status[fan1_status]
+    print '    Fan 2:    ', Fan_Status[fan2_status]
+
+    air_flow_reg = int(get_pmc_register('fan_tray_airflow'), 16)
+    air_flow_status = air_flow_reg & (1<<(tray-1)) >> (tray-1)
+    print '    Air Flow: ', Airflow_Direction[air_flow_status]
+
+
+print('\nFan Trays:')
+fan_tray_presence = get_pmc_register('fan_tray_presence')
+
+if (fan_tray_presence != 'ERR'):
+    fan_tray_presence = int(fan_tray_presence, 16)
+
+    for tray in range(0,S6100_MAX_FAN_TRAYS):
+        if (fan_tray_presence & (1<<tray)):
+            print_fan_tray(tray + 1)
+        else:
+            print '\n  Fan Tray ' + str(tray + 1) + ':  Not present'
+else:
+    logging.error('Unable to read FAN presence')
+
+#Print the information for 1 PSU
+def print_psu(psu):
+    Psu_Type = ['Normal', 'Mismatch']
+    Psu_Input_Type = ['AC', 'DC']
+    PSU_STATUS_TYPE_BIT = 4
+    PSU_STATUS_INPUT_TYPE_BIT = 1
+    PSU_FAN_PRESENT_BIT=2
+    PSU_FAN_STATUS_BIT=1
+    PSU_FAN_AIR_FLOW_BIT=0
+    Psu_Fan_Presence = ['Present', 'Absent']
+    Psu_Fan_Status = ['Normal', 'Abnormal']
+    Psu_Fan_Airflow = ['B2F', 'F2B']
+
+    print '  PSU ' + str(psu) + ':'
+    psu_status  = int(get_pmc_register('psu_'+str(psu)+'_status'), 16)
+
+    psu_type = (psu_status & (1<<PSU_STATUS_TYPE_BIT)) >> PSU_STATUS_TYPE_BIT
+    psu_input_type = (psu_status & (1<<PSU_STATUS_INPUT_TYPE_BIT)) >> PSU_STATUS_INPUT_TYPE_BIT
+
+    print '    Input:          ' , Psu_Input_Type[psu_input_type]
+    print '    Type:           ' , Psu_Type[psu_type]
+
+    # PSU FAN details
+    print '    FAN Speed:      ' , get_pmc_register('psu_'+str(psu)+'_fan_speed') , 'RPM'
+    psu_fan_status_reg = int(get_pmc_register('psu_'+str(psu)+'_fan_status'))
+    psu_fan_present = (psu_fan_status_reg & (1<<PSU_FAN_PRESENT_BIT)) >> PSU_FAN_PRESENT_BIT 
+    psu_fan_status = (psu_fan_status_reg & (1<<PSU_FAN_STATUS_BIT)) >> PSU_FAN_STATUS_BIT 
+    psu_fan_airflow = (psu_fan_status_reg & (1<<PSU_FAN_AIR_FLOW_BIT)) >> PSU_FAN_AIR_FLOW_BIT 
+    print '    FAN:            ' , Psu_Fan_Presence[psu_fan_present]
+    print '    FAN Status:     ' , Psu_Fan_Status[psu_fan_status]
+    print '    FAN AIRFLOW:    ' , Psu_Fan_Airflow[psu_fan_airflow]
+
+    # PSU input & output monitors
+    input_voltage = float(get_pmc_register('psu_'+str(psu)+'_input_voltage')) / 100
+    print '    Input Voltage:   %6.2f' % (input_voltage) , 'V'
+
+    output_voltage = float(get_pmc_register('psu_'+str(psu)+'_output_voltage')) / 100
+    print '    Output Voltage:  %6.2f' % (output_voltage) , 'V'
+
+    input_current = float(get_pmc_register('psu_'+str(psu)+'_input_current')) / 100
+    print '    Input Current:   %6.2f' % (input_current) , 'A'
+
+    output_current = float(get_pmc_register('psu_'+str(psu)+'_output_current')) / 100
+    print '    Output Current:  %6.2f' % (output_current) , 'A'
+
+    input_power = float(get_pmc_register('psu_'+str(psu)+'_input_power')) / 10
+    print '    Input Power:     %6.2f' % (input_power) , 'W'
+
+    output_power = float(get_pmc_register('psu_'+str(psu)+'_output_power')) / 10
+    print '    Output Power:    %6.2f' % (output_power) , 'W'
+
+    # PSU firmware gives spurious temperature reading without input power
+    if ( input_power != 0 ):
+        print '    Temperature:    ' , get_pmc_register('psu_'+str(psu)+'_temperature') , 'C'
+    else:
+        print '    Temperature:    ' , 'NA'
+
+print('\nPSUs:')
+for psu in range(1,S6100_MAX_PSUS+1):
+    psu_status = get_pmc_register('psu_'+str(psu)+'_status')
+
+    if ( psu_status != 'ERR' ):
+        psu_status = int(psu_status, 16)
+
+        # Check for PSU presence
+        if (~psu_status & 0b1):
+            print_psu(psu)
+        else:
+            print '\n  PSU ' , psu, 'Not present'
+    else:
+        logging.error('Unable to check PSU presence')
+
+print '\n  Total Power:      ', get_pmc_register('psu_total_power'), 'W'
+
+print('\nIO Modules:')
+
+for iom in range(1,S6100_MAX_IOMS+1):
+    print '  IOM '+ str(iom) + ': ' + iom_status_list[iom-1]
+
+print '\n'
+

--- a/z9100/scripts/platform_sensors.py
+++ b/z9100/scripts/platform_sensors.py
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+
+# On Z9100, the Platform Management Controller runs the
+# thermal algorithm. It provides a mailbox for the Host
+# to query relevant thermals. The dell_mailbox module
+# provides the sysfs support for the following objects:
+#   * onboard temperature sensors
+#   * FAN trays
+#   * PSU
+
+import os
+import sys
+import logging
+
+Z9100_MAX_FAN_TRAYS = 5
+Z9100_MAX_PSUS = 2
+
+MAILBOX_DIR="/sys/devices/platform/dell_mailbox"
+
+#Get a mailbox register
+def get_pmc_register(reg_name):
+    retval = 'ERR'
+    mb_reg_file = MAILBOX_DIR+'/'+reg_name
+    
+    if ( not os.path.isfile(mb_reg_file)):
+        print mb_reg_file,  'not found !'
+        return retval
+
+    try:
+        with open(mb_reg_file, 'r') as fd:
+            retval = fd.read()
+    except Exception as error:
+        logging.error("Unable to open ", mb_reg_file , "file !")
+
+    retval = retval.rstrip('\r\n')
+    return retval;
+
+logging.basicConfig(level=logging.DEBUG)
+
+if (os.path.isdir(MAILBOX_DIR)):
+    print 'dell-z9100-lpc'
+    print 'Adapter: Z9100 Platform Management Controller'
+else:
+    logging.error('Z9100 Platform Management Controller module not loaded !')
+    sys.exit(0)
+
+#Print the information for temperature sensors
+def print_temperature_sensors():
+    print("Onboard Temperature Sensors:")
+    print '  CPU:                           ' , get_pmc_register('temp_sensor_1') , 'C'
+    print '  BCM56960 (PSU side):           ' , get_pmc_register('temp_sensor_2') , 'C'
+    print '  System Inlet Left (IO side):   ' , get_pmc_register('temp_sensor_3') , 'C'
+    print '  System Inlet Right (IO side):  ' , get_pmc_register('temp_sensor_4') , 'C'
+    print '  BCM56960 (IO side):            ' , get_pmc_register('temp_sensor_6') , 'C'
+    print '  System Inlet Middle (PSU side):' , get_pmc_register('temp_sensor_9') , 'C'
+
+print_temperature_sensors()
+
+#Print the information for 1 Fan Tray
+def print_fan_tray(tray):
+
+    Fan_Status = ['Normal', 'Abnormal']
+    Airflow_Direction = ['B2F', 'F2B']
+
+    print '  Fan Tray ' + str(tray) + ':'
+    print '    Speed:    ' , get_pmc_register('fan_tray_'+str(tray)+'_speed') , 'RPM'
+
+    # Each fan tray has 2 fans. Each region register is 8 bits and has
+    # information for 4 trays. The region_b has information about the first
+    # 4 trays.
+    if ( tray <= 4 ):
+        fan_status_region = int(get_pmc_register('fan_status_region_b'), 16)
+    else:
+        fan_status_region = int(get_pmc_register('fan_status_region_a'), 16)
+
+    fan1_shift = (tray-1)*2
+    fan1_status = ( fan_status_region & (1<<fan1_shift) ) >> fan1_shift
+    fan2_shift = ((tray-1)*2) + 1
+    fan2_status = ( fan_status_region & (1<<fan2_shift) ) >> fan2_shift
+
+    print '    Fan 1:    ', Fan_Status[fan1_status]
+    print '    Fan 2:    ', Fan_Status[fan2_status]
+
+    air_flow_reg = int(get_pmc_register('fan_tray_airflow'), 16)
+    air_flow_status = air_flow_reg & (1<<(tray-1)) >> (tray-1)
+    print '    Air Flow: ', Airflow_Direction[air_flow_status]
+
+
+print('\nFan Trays:')
+fan_tray_presence = get_pmc_register('fan_tray_presence')
+
+if (fan_tray_presence != 'ERR'):
+    fan_tray_presence = int(fan_tray_presence, 16)
+
+    for tray in range(0,Z9100_MAX_FAN_TRAYS):
+        if (fan_tray_presence & (1<<tray)):
+            print_fan_tray(tray + 1)
+        else:
+            print '\n  Fan Tray ' + str(tray + 1) + ':  Not present'
+else:
+    logging.error('Unable to read FAN presence')
+
+#Print the information for 1 PSU
+def print_psu(psu):
+    Psu_Type = ['Normal', 'Mismatch']
+    Psu_Input_Type = ['AC', 'DC']
+    PSU_STATUS_TYPE_BIT = 4
+    PSU_STATUS_INPUT_TYPE_BIT = 1
+    PSU_FAN_PRESENT_BIT=2
+    PSU_FAN_STATUS_BIT=1
+    PSU_FAN_AIR_FLOW_BIT=0
+    Psu_Fan_Presence = ['Present', 'Absent']
+    Psu_Fan_Status = ['Normal', 'Abnormal']
+    Psu_Fan_Airflow = ['B2F', 'F2B']
+
+    print '  PSU ' + str(psu) + ':'
+    psu_status  = int(get_pmc_register('psu_'+str(psu)+'_status'), 16)
+
+    psu_type = (psu_status & (1<<PSU_STATUS_TYPE_BIT)) >> PSU_STATUS_TYPE_BIT
+    psu_input_type = (psu_status & (1<<PSU_STATUS_INPUT_TYPE_BIT)) >> PSU_STATUS_INPUT_TYPE_BIT
+
+    print '    Input:          ' , Psu_Input_Type[psu_input_type]
+    print '    Type:           ' , Psu_Type[psu_type]
+
+    # PSU FAN details
+    print '    FAN Speed:      ' , get_pmc_register('psu_'+str(psu)+'_fan_speed') , 'RPM'
+    psu_fan_status_reg = int(get_pmc_register('psu_'+str(psu)+'_fan_status'))
+    psu_fan_present = (psu_fan_status_reg & (1<<PSU_FAN_PRESENT_BIT)) >> PSU_FAN_PRESENT_BIT 
+    psu_fan_status = (psu_fan_status_reg & (1<<PSU_FAN_STATUS_BIT)) >> PSU_FAN_STATUS_BIT 
+    psu_fan_airflow = (psu_fan_status_reg & (1<<PSU_FAN_AIR_FLOW_BIT)) >> PSU_FAN_AIR_FLOW_BIT 
+    print '    FAN:            ' , Psu_Fan_Presence[psu_fan_present]
+    print '    FAN Status:     ' , Psu_Fan_Status[psu_fan_status]
+    print '    FAN AIRFLOW:    ' , Psu_Fan_Airflow[psu_fan_airflow]
+
+    # PSU input & output monitors
+    input_voltage = float(get_pmc_register('psu_'+str(psu)+'_input_voltage')) / 100
+    print '    Input Voltage:   %6.2f' % (input_voltage) , 'V'
+
+    output_voltage = float(get_pmc_register('psu_'+str(psu)+'_output_voltage')) / 100
+    print '    Output Voltage:  %6.2f' % (output_voltage) , 'V'
+
+    input_current = float(get_pmc_register('psu_'+str(psu)+'_input_current')) / 100
+    print '    Input Current:   %6.2f' % (input_current) , 'A'
+
+    output_current = float(get_pmc_register('psu_'+str(psu)+'_output_current')) / 100
+    print '    Output Current:  %6.2f' % (output_current) , 'A'
+
+    input_power = float(get_pmc_register('psu_'+str(psu)+'_input_power')) / 10
+    print '    Input Power:     %6.2f' % (input_power) , 'W'
+
+    output_power = float(get_pmc_register('psu_'+str(psu)+'_output_power')) / 10
+    print '    Output Power:    %6.2f' % (output_power) , 'W'
+
+    # PSU firmware gives spurious temperature reading without input power
+    if ( input_power != 0 ):
+        print '    Temperature:    ' , get_pmc_register('psu_'+str(psu)+'_temperature') , 'C'
+    else:
+        print '    Temperature:    ' , 'NA'
+
+print('\nPSUs:')
+for psu in range(1,Z9100_MAX_PSUS+1):
+    psu_status = get_pmc_register('psu_'+str(psu)+'_status')
+
+    if ( psu_status != 'ERR' ):
+        psu_status = int(psu_status, 16)
+
+        # Check for PSU presence
+        if (~psu_status & 0b1):
+            print_psu(psu)
+        else:
+            print '\n  PSU ' , psu, 'Not present'
+    else:
+        logging.error('Unable to check PSU presence')
+
+print '\n  Total Power:      ', get_pmc_register('psu_total_power'), 'W'
+
+print '\n'


### PR DESCRIPTION
1. Add a platform specific script (platform_sensors.py) for Z9100 and S6100 that can be called from sensors to dump information retrieved from the Platform Management Controller.
2. Update the Z9100 (dell_mailbox) and S6100 (dell_s6100_lpc) modules:
    a. To support more relevant thermal sensors, PSU & FAN information
    b. Add spinlock while reading mailbox.

Note that when the above modules become lm-sensors compliant (and register with hwmon), the platform_sensors can be deprecated.