### PR TITLE
Add eeprom driver for only valid devices

### DIFF
--- a/s6100/scripts/s6100_platform.sh
+++ b/s6100/scripts/s6100_platform.sh
@@ -149,15 +149,15 @@ switch_board_qsfp() {
     fi
 
     if [ -e  /sys/bus/i2c/devices/i2c-34 ]; then
-        qsfp_device_mod $1 18 33
+        qsfp_device_mod $1 34 49
     fi
 
     if [ -e  /sys/bus/i2c/devices/i2c-50 ]; then
-        qsfp_device_mod $1 18 33
+        qsfp_device_mod $1 50 65
     fi
 
     if [ -e  /sys/bus/i2c/devices/i2c-66 ]; then
-        qsfp_device_mod $1 18 33
+        qsfp_device_mod $1 66 81
     fi
 }
 


### PR DESCRIPTION
1.  While adding eeprom devices, missed to initialize all ports.
2.  Removed invalid ports and added valid port numbers for all IOM's.
3.  No failure message logs seen on the console.
4. #22 