### PR TITLE
Remove redundant sleep during i2c device instantiation

### DIFF
--- a/common/dell_i2c_utils.sh
+++ b/common/dell_i2c_utils.sh
@@ -1,0 +1,62 @@
+# Perform an i2c device configuration : instantiate / delete.
+# Input is of the form:
+# "echo [driver] <i2c-address> >  <i2c-bus/operation>"
+# where operation = "new_device" or "delete_device"
+
+i2c_config() {
+    local count=0
+    local MAX_BUS_RETRY=20
+    local MAX_I2C_OP_RETRY=10
+
+    i2c_bus_op=`echo "$@" | cut -d'>' -f 2`
+    i2c_bus=$(dirname $i2c_bus_op)
+
+    # check if bus exists
+    while [[ "$count" -lt "$MAX_BUS_RETRY" ]]; do
+        [[ -e $i2c_bus ]] && break || sleep .1
+        count=$((count+1))
+    done
+
+    if [[ "$count" -eq "$MAX_BUS_RETRY" ]]; then
+        echo "ERROR: $@ : i2c bus not created"
+        return
+    fi
+
+    # perform the add/delete
+    count=0
+    while [[ "$count" -lt "$MAX_I2C_OP_RETRY" ]]; do
+        eval "$@" > /dev/null 2>&1
+        [[ $? == 0 ]] && break || sleep .2
+        count=$((count+1))
+    done
+
+    if [[ "$count" -eq "$MAX_I2C_OP_RETRY" ]]; then
+        echo "ERROR: $@ : i2c operation failed"
+        return
+    fi
+}
+
+# Check if a i2c bus exists. Poll for upto 2 seconds since mux creation may take time..
+# Input: bus to check for existence
+
+i2c_poll_bus_exists() {
+    local count=0
+    local MAX_BUS_RETRY=20
+    local i2c_bus
+
+    i2c_bus=$1
+
+    # check if bus exists
+    while [[ "$count" -lt "$MAX_BUS_RETRY" ]]; do
+        [[ -e $i2c_bus ]] && break || sleep .1
+        count=$((count+1))
+    done
+
+    if [[ "$count" -eq "$MAX_BUS_RETRY" ]]; then
+        echo "ERROR: $@ : i2c bus not created"
+        return 1
+    else
+        return 0
+    fi
+}
+

--- a/debian/platform-modules-s6100.install
+++ b/debian/platform-modules-s6100.install
@@ -1,6 +1,7 @@
 s6100/scripts/io_rd_wr.py usr/local/bin
 s6100/scripts/iom_power_*.sh usr/local/bin
 s6100/scripts/s6100_platform.sh usr/local/bin
+common/dell_i2c_utils.sh usr/local/bin
 s6100/scripts/platform_sensors.py usr/local/bin
 s6100/scripts/sensors usr/bin
 

--- a/debian/platform-modules-z9100.install
+++ b/debian/platform-modules-z9100.install
@@ -1,5 +1,6 @@
 z9100/scripts/check_qsfp.sh usr/local/bin
 z9100/scripts/z9100_platform.sh usr/local/bin
+common/dell_i2c_utils.sh usr/local/bin
 z9100/scripts/platform_sensors.py usr/local/bin
 z9100/scripts/sensors usr/bin
 z9100/cfg/z9100-modules.conf etc/modules-load.d

--- a/s6100/scripts/s6100_platform.sh
+++ b/s6100/scripts/s6100_platform.sh
@@ -16,38 +16,74 @@ init_devnum() {
     [ $found -eq 0 ] && echo "cannot find iSMT" && exit 1
 }
 
+# Perform an i2c device configuration : instantiate / delete.
+# Input is of the form:
+# "echo [driver] <i2c-address> >  <i2c-bus/operation>"
+# where operation = "new_device" or "delete_device"
+
+i2c_config() {
+    local count=0
+    local MAX_BUS_RETRY=20
+    local MAX_I2C_OP_RETRY=10
+
+    i2c_bus_op=`echo "$@" | cut -d'>' -f 2`
+    i2c_bus=$(dirname $i2c_bus_op)
+
+    # check if bus exists
+    while [ "$count" -lt "$MAX_BUS_RETRY" ]; do
+        [ -e $i2c_bus ] && break || sleep .1
+        count=$((count+1))
+    done
+
+    if [[ "$count" == "$MAX_BUS_RETRY" ]]; then
+        echo "ERROR: $@ : i2c bus not created"
+        return
+    fi
+
+    # perform the add/delete
+    count=0
+    while [ "$count" -lt "$MAX_I2C_OP_RETRY" ]; do
+        eval "$@" > /dev/null 2>&1
+        [ $? == 0 ] && break || sleep .2
+        count=$((count+1))
+    done
+
+    if [[ "$count" == "$MAX_I2C_OP_RETRY" ]]; then
+        echo "ERROR: $@ : i2c operation failed"
+        return
+    fi
+}
+
 # Attach/Detach CPU board mux @ 0x70
 cpu_board_mux() {
     case $1 in
-        "new_device")    echo pca9547 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/$1
+        "new_device")    i2c_config "echo pca9547 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/$1"
                          ;;
-        "delete_device") echo 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/$1
+        "delete_device") i2c_config "echo 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/$1"
                          ;;
         *)               echo "s6100_platform: cpu_board_mux: invalid command !"
                          ;;
     esac
-    sleep 2
 }
 
 # Attach/Detach Switchboard MUX @ 0x71
 switch_board_mux() {
     case $1 in
-        "new_device")    echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-4/$1
+        "new_device")    i2c_config "echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-4/$1"
                          ;;
-        "delete_device") echo 0x71 > /sys/bus/i2c/devices/i2c-4/$1
+        "delete_device") i2c_config "echo 0x71 > /sys/bus/i2c/devices/i2c-4/$1"
                          ;;
         *)               echo "s6100_platform: switch_board_mux : invalid command !"
                          ;;
     esac
-    sleep 2
 }
 
 # Attach/Detach syseeprom on CPU board
 sys_eeprom() {
     case $1 in
-        "new_device")    echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-2/$1
+        "new_device")    i2c_config "echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-2/$1"
                          ;;
-        "delete_device") echo 0x50 > /sys/bus/i2c/devices/i2c-2/$1
+        "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-2/$1"
                          ;;
         *)               echo "s6100_platform: sys_eeprom : invalid command !"
                          ;;
@@ -60,15 +96,13 @@ switch_board_cpld() {
         "new_device")    
                       for ((i=14;i<=17;i++));
                       do
-                          echo  dell_s6100_iom_cpld 0x3e > /sys/bus/i2c/devices/i2c-$i/$1
-                          sleep 2
+                          i2c_config "echo  dell_s6100_iom_cpld 0x3e > /sys/bus/i2c/devices/i2c-$i/$1"
                       done
                       ;;
         "delete_device")
                       for ((i=14;i<=17;i++));
                       do
-                          echo  0x3e > /sys/bus/i2c/devices/i2c-$i/$1
-                          sleep 2
+                          i2c_config "echo  0x3e > /sys/bus/i2c/devices/i2c-$i/$1"
                       done
                       ;;
         *)            echo "s6100_platform: switch_board_cpld : invalid command !"
@@ -85,10 +119,8 @@ switch_board_qsfp_mux() {
                           # 0x71 mux on the IOM 1
                           mux_index=$(expr $i - 5)
                           echo "Attaching PCA9548 $mux_index"
-                          echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-$i/$1
-                          sleep 2
-                          echo pca9548 0x72 > /sys/bus/i2c/devices/i2c-$i/$1
-                          sleep 2
+                          i2c_config "echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-$i/$1"
+                          i2c_config "echo pca9548 0x72 > /sys/bus/i2c/devices/i2c-$i/$1"
                       done
                       ;;
         "delete_device")
@@ -97,26 +129,23 @@ switch_board_qsfp_mux() {
                           # 0x71 mux on the IOM 1
                           mux_index=$(expr $i - 5)
                           echo "Detaching PCA9548 $mux_index"
-                          echo 0x71 > /sys/bus/i2c/devices/i2c-$devnum/i2c-$i/$1
-                          sleep 2
-                          echo 0x72 > /sys/bus/i2c/devices/i2c-$devnum/i2c-$i/$1
-                          sleep 2
+                          i2c_config "echo 0x71 > /sys/bus/i2c/devices/i2c-$devnum/i2c-$i/$1"
+                          i2c_config "echo 0x72 > /sys/bus/i2c/devices/i2c-$devnum/i2c-$i/$1"
                       done
                       ;;
         *)            echo "s6100_platform: switch_board_qsfp_mux: invalid command !"
                       ;;
     esac
-    sleep 2
 }
 
 #Attach/Detach the SFP modules on PCA9548_2
 switch_board_sfp() {
     case $1 in
-        "new_device")    echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-11/$1
-                         echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-12/$1
+        "new_device")    i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
+                         i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
                          ;;
-        "delete_device") echo 0x50 > /sys/bus/i2c/devices/i2c-11/$1
-                         echo 0x50 > /sys/bus/i2c/devices/i2c-12/$1
+        "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
+                         i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
                          ;;
         *)               echo "s6100_platform: switch_board_sfp: invalid command !"
                          ;;
@@ -128,12 +157,12 @@ qsfp_device_mod() {
     case $1 in
         "new_device")    for ((i=$2;i<=$3;i++));
                          do
-                             echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                             i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
                          done
                          ;;
         "delete_device") for ((i=$2;i<=$3;i++));
                          do
-                             echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                             i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
                          done
                          ;;
         *)              echo "s6100_platform: qsfp_device_mod: invalid command $1:$2,$3!"

--- a/z9100/scripts/z9100_platform.sh
+++ b/z9100/scripts/z9100_platform.sh
@@ -16,38 +16,74 @@ init_devnum() {
     [ $found -eq 0 ] && echo "cannot find iSMT" && exit 1
 }
 
+# Perform an i2c device configuration : instantiate / delete.
+# Input is of the form:
+# "echo [driver] <i2c-address> >  <i2c-bus/operation>"
+# where operation = "new_device" or "delete_device"
+
+i2c_config() {
+    local count=0
+    local MAX_BUS_RETRY=20
+    local MAX_I2C_OP_RETRY=10
+
+    i2c_bus_op=`echo "$@" | cut -d'>' -f 2`
+    i2c_bus=$(dirname $i2c_bus_op)
+
+    # check if bus exists
+    while [ "$count" -lt "$MAX_BUS_RETRY" ]; do
+        [ -e $i2c_bus ] && break || sleep .1
+        count=$((count+1))
+    done
+
+    if [[ "$count" == "$MAX_BUS_RETRY" ]]; then
+        echo "ERROR: $@ : i2c bus not created"
+        return
+    fi
+
+    # perform the add/delete
+    count=0
+    while [ "$count" -lt "$MAX_I2C_OP_RETRY" ]; do
+        eval "$@" > /dev/null 2>&1
+        [ $? == 0 ] && break || sleep .2
+        count=$((count+1))
+    done
+
+    if [[ "$count" == "$MAX_I2C_OP_RETRY" ]]; then
+        echo "ERROR: $@ : i2c operation failed"
+        return
+    fi
+}
+
 # Attach/Detach CPU board mux @ 0x70
 cpu_board_mux() {
     case $1 in
-        "new_device")    echo pca9547 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/$1
+        "new_device")    i2c_config "echo pca9547 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/$1"
                          ;;
-        "delete_device") echo 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/$1
+        "delete_device") i2c_config "echo 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/$1"
                          ;;
         *)               echo "z9100_platform: cpu_board_mux: invalid command !"
                          ;;
     esac
-    sleep 2
 }
 
 # Attach/Detach switch board MUX to IOM CPLDs @ 0x71
 switch_board_mux() {
     case $1 in
-        "new_device")    echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-4/$1
+        "new_device")    i2c_config "echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-4/$1"
                          ;;
-        "delete_device") echo 0x71 > /sys/bus/i2c/devices/i2c-4/$1
+        "delete_device") i2c_config "echo 0x71 > /sys/bus/i2c/devices/i2c-4/$1"
                          ;;
         *)               echo "z9100_platform: switch_board_mux : invalid command !"
                          ;;
     esac
-    sleep 2
 }
 
 # Attach/Detach syseeprom on CPU board
 sys_eeprom() {
     case $1 in
-        "new_device")    echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-2/$1
+        "new_device")    i2c_config "echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-2/$1"
                          ;;
-        "delete_device") echo 0x50 > /sys/bus/i2c/devices/i2c-2/$1
+        "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-2/$1"
                          ;;
         *)               echo "z9100_platform: sys_eeprom : invalid command !"
                          ;;
@@ -60,15 +96,13 @@ switch_board_cpld() {
         "new_device")    
                       for ((i=14;i<=17;i++));
                       do
-                          echo  dell_z9100_iom_cpld 0x3e > /sys/bus/i2c/devices/i2c-$i/$1
-                          sleep 2
+                          i2c_config "echo  dell_z9100_iom_cpld 0x3e > /sys/bus/i2c/devices/i2c-$i/$1"
                       done
                       ;;
         "delete_device")
                       for ((i=14;i<=17;i++));
                       do
-                          echo  0x3e > /sys/bus/i2c/devices/i2c-$i/$1
-                          sleep 2
+                          i2c_config "echo  0x3e > /sys/bus/i2c/devices/i2c-$i/$1"
                       done
                       ;;
         *)            echo "z9100_platform: switch_board_cpld : invalid command !"
@@ -85,8 +119,7 @@ switch_board_qsfp_mux() {
                           # 0x71 mux on the IOM 1
                           mux_index=$(expr $i - 5)
                           echo "Attaching PCA9548 $mux_index"
-                          echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-$i/$1
-                          sleep 2
+                          i2c_config "echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-$i/$1"
                       done
                       ;;
         "delete_device")
@@ -95,24 +128,22 @@ switch_board_qsfp_mux() {
                           # 0x71 mux on the IOM 1
                           mux_index=$(expr $i - 5)
                           echo "Detaching PCA9548 $mux_index"
-                          echo 0x71 > /sys/bus/i2c/devices/i2c-$devnum/i2c-$i/$1
-                          sleep 2
+                          i2c_config "echo 0x71 > /sys/bus/i2c/devices/i2c-$devnum/i2c-$i/$1"
                       done
                       ;;
         *)            echo "z9100_platform: switch_board_qsfp_mux: invalid command !"
                       ;;
     esac
-    sleep 2
 }
 
 #Attach/Detach the SFP modules on PCA9548_2
 switch_board_sfp() {
     case $1 in
-        "new_device")    echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-11/$1
-                         echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-12/$1
+        "new_device")    i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
+                         i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
                          ;;
-        "delete_device") echo 0x50 > /sys/bus/i2c/devices/i2c-11/$1
-                         echo 0x50 > /sys/bus/i2c/devices/i2c-12/$1
+        "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
+                         i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
                          ;;
         *)               echo "z9100_platform: switch_board_sfp: invalid command !"
                          ;;
@@ -126,13 +157,13 @@ switch_board_qsfp() {
         "new_device")
                         for ((i=18;i<=49;i++));
                         do
-                            echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                            i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
                         done
                         ;;
         "delete_device")
                         for ((i=18;i<=49;i++));
                         do
-                            echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                            i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
                         done
                         ;;
 


### PR DESCRIPTION
This is to fix:
https://github.com/Azure/sonic-platform-modules-dell/issues/27
too many sleeps in s6100_platform.sh