### PR TITLE
Enable/disable fstrim on S6100 & Z9100

### DIFF
--- a/s6100/scripts/s6100_platform.sh
+++ b/s6100/scripts/s6100_platform.sh
@@ -188,6 +188,10 @@ if [[ "$1" == "init" ]]; then
     switch_board_sfp "new_device"
     switch_board_qsfp "new_device"
     switch_board_qsfp_lpmode "disable"
+
+    # Enable fstrim
+    systemctl start fstrim.timer
+    systemctl start fstrim.service
 elif [[ "$1" == "deinit" ]]; then
     switch_board_sfp "delete_device"
     switch_board_cpld "delete_device"
@@ -201,6 +205,10 @@ elif [[ "$1" == "deinit" ]]; then
     modprobe -r dell_s6100_iom_cpld
     modprobe -r i2c-mux-pca954x
     modprobe -r i2c-dev
+
+    # Disable fstrim
+    systemctl stop fstrim.service
+    systemctl stop fstrim.timer
 else
      echo "s6100_platform : Invalid option !"
 fi

--- a/z9100/scripts/z9100_platform.sh
+++ b/z9100/scripts/z9100_platform.sh
@@ -152,6 +152,10 @@ if [[ "$1" == "init" ]]; then
     switch_board_qsfp_mux "new_device"
     switch_board_sfp "new_device"
     switch_board_qsfp "new_device"
+
+    # Enable fstrim
+    systemctl start fstrim.timer
+    systemctl start fstrim.service
 elif [[ "$1" == "deinit" ]]; then
     switch_board_sfp "delete_device"
     switch_board_cpld "delete_device"
@@ -165,6 +169,10 @@ elif [[ "$1" == "deinit" ]]; then
     modprobe -r dell_mailbox
     modprobe -r i2c-mux-pca954x
     modprobe -r i2c-dev
+
+    # Disable fstrim
+    systemctl stop fstrim.service
+    systemctl stop fstrim.timer
 else
      echo "z9100_platform : Invalid option !"
 fi


### PR DESCRIPTION
Enable / Disable fstrim during Dell submodule init/de-init.