### PR TITLE
Add BCM sensor values. Remove BCM & CPU internal listing from PMC

### DIFF
--- a/common/dell_pmc.c
+++ b/common/dell_pmc.c
@@ -208,8 +208,8 @@ static const char *const s6100_temp_label[] = {
         "U2 Switch board?",
         "Front GE",
         "Front SFP+",
-        "BCM Internal",
-        "CPU Internal",
+        "Unused",
+        "Unused",
         "",
 	"PSU 1",
 	"PSU 2"

--- a/s6100/scripts/platform_sensors.py
+++ b/s6100/scripts/platform_sensors.py
@@ -11,6 +11,8 @@
 import os
 import sys
 import logging
+import subprocess
+import re
 
 S6100_MAX_FAN_TRAYS = 4
 S6100_MAX_PSUS = 2
@@ -319,4 +321,79 @@ print('\nIO Modules:')
 for iom in range(1, S6100_MAX_IOMS+1):
     print '  IOM ' + str(iom) + ' :' + iom_status_list[iom - 1]
 
-print '\n'
+# Print the BCM internal current and peak temperatures
+
+# TH has 8 internal sensors
+MAX_BCM_TEMP_SENSORS = 8
+
+# List that holds the currently monitored values
+bcm_sensors_curr = []
+# List that holds the peak monitored values
+bcm_sensors_peak = []
+
+# Given a sensor register dump, extract either
+# the current/peak field and convert to Celsius
+
+
+def get_sensor_value(buf, type):
+    BCM_TEMP_MAX = 410040
+    BCM_TEMP_MUL = 487
+    BCM_TEMP_DIV = 1000
+
+    # Set the search string appropriately
+    if (type == 'CURR'):
+        pattern = ",PVT_DATA="
+    elif (type == 'PEAK'):
+        pattern = "MIN_PVT_DATA="
+    else:
+        return 0
+
+    regex = re.escape(pattern) + "(.+?),"
+    try:
+        tmp = re.search(regex, buf).group(1)
+    except AttributeError:
+        return 0
+
+    # Strip the leading '0x'
+    tmp = int(tmp[2:], 16)
+
+    # BCM stores the temperature as a inverse.
+    # Scale down into a normal Celsius value.
+    tmp = BCM_TEMP_MUL * tmp
+    if (tmp > BCM_TEMP_MAX):
+        return 0
+
+    tmp = (BCM_TEMP_MAX - tmp) / BCM_TEMP_DIV
+    return tmp
+
+# Update the current and peak values for a given sensor
+
+
+def update_bcm_sensor(index):
+    cmd = 'g TOP_PVTMON_RESULT_'+str(index)
+
+    # Get the register dump
+    retbuf = subprocess.check_output(['bcmcmd', cmd])
+
+    # Get the current temperature reading
+    currval = get_sensor_value(retbuf, "CURR")
+    bcm_sensors_curr.append(currval)
+
+    # Get the peak temperature reading
+    peakval = get_sensor_value(retbuf, "PEAK")
+    bcm_sensors_peak.append(peakval)
+
+# Check if syncd is up
+cmd = 'docker ps'
+syncd_status = subprocess.check_output([cmd], shell=True)
+
+if "syncd" in syncd_status.split():
+    for i in range(0, MAX_BCM_TEMP_SENSORS):
+        update_bcm_sensor(i)
+
+    print '\nBCM Internal :       ' \
+          + '+' + str(max(bcm_sensors_curr)) + ' C' \
+          + '  (peak = +' + str(max(bcm_sensors_peak)) + ' C)'
+else:
+    print '\nBCM Internal :       ' + 'NA'
+


### PR DESCRIPTION
1.	The BCM & CPU Internal temperature strings are present only for S6100. I’ve marked both as “Unused” since the SMF does not retrieve these. Also, CPU Internal is not necessary from SMF since the coretemp-isa driver dumps it anyway. The entries are marked “unused” instead of being deleted to preserve formatting.
2.	BCM sensors are being retrieved for both S6100 & Z9100. Added a check to see if syncd is up before bcmcmd can be issued.
3.	Fixed a nit in Z9100 sensors that indicated it’s a S6100 (typo from another commit).