### PR TITLE
Move depmod -a to debian init

### DIFF
--- a/debian/platform-modules-s6100.init
+++ b/debian/platform-modules-s6100.init
@@ -15,6 +15,8 @@ case "$1" in
 start)
     echo -n "Setting up board... "
 
+    depmod -a
+
     /usr/local/bin/iom_power_on.sh
     /usr/local/bin/s6100_platform.sh init
 

--- a/debian/platform-modules-z9100.init
+++ b/debian/platform-modules-z9100.init
@@ -15,6 +15,8 @@ case "$1" in
 start)
     echo -n "Setting up board... "
 
+    depmod -a
+
     # /usr/local/bin/iom_power_on.sh
     /usr/local/bin/z9100_platform.sh init
 

--- a/debian/platform-modules-z9264f.init
+++ b/debian/platform-modules-z9264f.init
@@ -15,6 +15,8 @@ case "$1" in
 start)
     echo -n "Setting up board... "
 
+    depmod -a
+
     # /usr/local/bin/iom_power_on.sh
     /usr/local/bin/z9264f_platform.sh init
 

--- a/s6100/scripts/s6100_platform.sh
+++ b/s6100/scripts/s6100_platform.sh
@@ -174,7 +174,6 @@ switch_board_qsfp_lpmode() {
 init_devnum
 
 if [[ "$1" == "init" ]]; then
-    depmod -a
     modprobe i2c-dev
     modprobe i2c-mux-pca954x force_deselect_on_exit=1
     modprobe dell_s6100_iom_cpld

--- a/z9100/scripts/z9100_platform.sh
+++ b/z9100/scripts/z9100_platform.sh
@@ -139,7 +139,6 @@ switch_board_qsfp() {
 init_devnum
 
 if [[ "$1" == "init" ]]; then
-    depmod -a
     modprobe i2c-dev
     modprobe i2c-mux-pca954x force_deselect_on_exit=1
     modprobe dell_mailbox

--- a/z9264f/scripts/z9264f_platform.sh
+++ b/z9264f/scripts/z9264f_platform.sh
@@ -102,7 +102,6 @@ switch_board_modsel() {
 init_devnum
 
 if [ "$1" == "init" ]; then
-    depmod -a
     modprobe i2c-dev
     modprobe i2c-mux-pca954x force_deselect_on_exit=1
     modprobe i2c_ocores


### PR DESCRIPTION
Moved the depmod from the platform init script to debian init.

1.	Did fresh ONIE install, sonic_installer install to check that the i2c tree gets created
2.	Perform reboot and checked the module init
3.	Did “/usr/local/bin/s6100_platform.sh deinit” and “/usr/local/bin/s6100_platform.sh init” multiple times to check that the /lib/modules/3.16.0-5-amd64/modules.* timestamps don’t change...
