### PR TITLE
Added systemd support for Dell Z9100/S6100 Platform Modules

### DIFF
--- a/debian/platform-modules-s6100.install
+++ b/debian/platform-modules-s6100.install
@@ -6,4 +6,4 @@ common/fstrim.timer etc/systemd/system
 common/fstrim.service etc/systemd/system
 s6100/scripts/platform_sensors.py usr/local/bin
 s6100/scripts/sensors usr/bin
-
+s6100/systemd/platform-modules-s6100.service etc/systemd/system/multi-user.target.wants

--- a/debian/platform-modules-z9100.install
+++ b/debian/platform-modules-z9100.install
@@ -6,3 +6,4 @@ common/fstrim.service etc/systemd/system
 z9100/scripts/platform_sensors.py usr/local/bin
 z9100/scripts/sensors usr/bin
 z9100/cfg/z9100-modules.conf etc/modules-load.d
+z9100/systemd/platform-modules-z9100.service etc/systemd/system/multi-user.target.wants

--- a/s6100/systemd/platform-modules-s6100.service
+++ b/s6100/systemd/platform-modules-s6100.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Dell S6100 Platform modules
+Before=pmon.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/local/bin/iom_power_on.sh
+ExecStart=/usr/local/bin/s6100_platform.sh init
+ExecStop=/usr/local/bin/s6100_platform.sh deinit
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/z9100/scripts/platform_sensors.py
+++ b/z9100/scripts/platform_sensors.py
@@ -16,7 +16,7 @@ Z9100_MAX_FAN_TRAYS = 5
 Z9100_MAX_PSUS = 2
 S6100_MAX_IOMS = 4
 
-MAILBOX_DIR = "/sys/devices/platform/SMF.512/hwmon/hwmon1"
+MAILBOX_DIR = "/sys/devices/platform/SMF.512/hwmon/hwmon0"
 
 # Get a mailbox register
 
@@ -42,10 +42,10 @@ def get_pmc_register(reg_name):
 logging.basicConfig(level=logging.DEBUG)
 
 if (os.path.isdir(MAILBOX_DIR)):
-    print 'dell-s6100-lpc'
-    print 'Adapter: S6100 Platform Management Controller'
+    print 'dell-z9100-lpc'
+    print 'Adapter: Z9100 Platform Management Controller'
 else:
-    logging.error('S6100 Platform Management Controller module not loaded !')
+    logging.error('Z9100 Platform Management Controller module not loaded !')
     # sys.exit(0)
 
 # Print the information for temperature sensors

--- a/z9100/systemd/platform-modules-z9100.service
+++ b/z9100/systemd/platform-modules-z9100.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Dell Z9100 Platform modules
+Before=pmon.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/z9100_platform.sh init
+ExecStop=/usr/local/bin/z9100_platform.sh deinit
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
 - Added platform-modules-s6100.service  and platform-modules-z9100.service systemd files to start dell platform modules in above platforms.
- Modified scripts for new changes.
