### PR TITLE
Added platform module start/stop service for Dell S6100/Z9100 platforms

### DIFF
--- a/debian/platform-modules-s6100.install
+++ b/debian/platform-modules-s6100.install
@@ -6,4 +6,4 @@ common/fstrim.timer etc/systemd/system
 common/fstrim.service etc/systemd/system
 s6100/scripts/platform_sensors.py usr/local/bin
 s6100/scripts/sensors usr/bin
-
+s6100/systemd/platform-modules-s6100.service etc/systemd/system

--- a/debian/platform-modules-s6100.postinst
+++ b/debian/platform-modules-s6100.postinst
@@ -4,4 +4,8 @@
 systemctl enable fstrim.timer
 systemctl start fstrim.timer
 
+#Enable Dell-S6100-platform-service
+depmod -a
+systemctl enable platform-modules-s6100.service
+systemctl start platform-modules-s6100.service
 #DEBHELPER#

--- a/debian/platform-modules-z9100.install
+++ b/debian/platform-modules-z9100.install
@@ -6,3 +6,4 @@ common/fstrim.service etc/systemd/system
 z9100/scripts/platform_sensors.py usr/local/bin
 z9100/scripts/sensors usr/bin
 z9100/cfg/z9100-modules.conf etc/modules-load.d
+z9100/systemd/platform-modules-z9100.service etc/systemd/system

--- a/debian/platform-modules-z9100.postinst
+++ b/debian/platform-modules-z9100.postinst
@@ -4,4 +4,9 @@
 systemctl enable fstrim.timer
 systemctl start fstrim.timer
 
+# Enable Dell-Z9100-platform-service
+depmod -a
+systemctl enable platform-modules-z9100.service
+systemctl start platform-modules-z9100.service
+
 #DEBHELPER#

--- a/s6100/systemd/platform-modules-s6100.service
+++ b/s6100/systemd/platform-modules-s6100.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Dell S6100 Platform modules
+Before=pmon.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/local/bin/iom_power_on.sh
+ExecStart=/usr/local/bin/s6100_platform.sh init
+ExecStop=/usr/local/bin/s6100_platform.sh deinit
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/z9100/systemd/platform-modules-z9100.service
+++ b/z9100/systemd/platform-modules-z9100.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Dell Z9100 Platform modules
+Before=pmon.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/z9100_platform.sh init
+ExecStop=/usr/local/bin/z9100_platform.sh deinit
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
-What I did

- Introduced systemd .service files to start and stop platform drivers.

- Moved depmod in *.postinst files. So, during first-time boot depmod is triggered post package installation and drivers will be loaded without any issues.

[depmod-logs-for-S6100-Z9100.txt](https://github.com/Azure/sonic-platform-modules-dell/files/2428161/depmod-logs-for-S6100-Z9100.txt)
