### PR TITLE
[sonic-platforms-modules-dell] backport to 201807

### DIFF
--- a/debian/platform-modules-s6100.install
+++ b/debian/platform-modules-s6100.install
@@ -6,4 +6,4 @@ common/fstrim.timer etc/systemd/system
 common/fstrim.service etc/systemd/system
 s6100/scripts/platform_sensors.py usr/local/bin
 s6100/scripts/sensors usr/bin
-
+s6100/systemd/platform-modules-s6100.service etc/systemd/system

--- a/debian/platform-modules-s6100.postinst
+++ b/debian/platform-modules-s6100.postinst
@@ -4,4 +4,9 @@
 systemctl enable fstrim.timer
 systemctl start fstrim.timer
 
+# Enable Dell-S6100-platform-service  
+depmod -a   
+systemctl enable platform-modules-s6100.service  
+systemctl start platform-modules-s6100.service 
+
 #DEBHELPER#

--- a/debian/platform-modules-z9100.install
+++ b/debian/platform-modules-z9100.install
@@ -6,3 +6,4 @@ common/fstrim.service etc/systemd/system
 z9100/scripts/platform_sensors.py usr/local/bin
 z9100/scripts/sensors usr/bin
 z9100/cfg/z9100-modules.conf etc/modules-load.d
+z9100/systemd/platform-modules-z9100.service etc/systemd/system

--- a/debian/platform-modules-z9100.postinst
+++ b/debian/platform-modules-z9100.postinst
@@ -4,4 +4,9 @@
 systemctl enable fstrim.timer
 systemctl start fstrim.timer
 
+# Enable Dell-Z9100-platform-service  
+depmod -a   
+systemctl enable platform-modules-z9100.service  
+systemctl start platform-modules-z9100.service  
+
 #DEBHELPER#

--- a/s6100/systemd/platform-modules-s6100.service
+++ b/s6100/systemd/platform-modules-s6100.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Dell S6100 Platform modules
+Before=pmon.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/local/bin/iom_power_on.sh
+ExecStart=/usr/local/bin/s6100_platform.sh init
+ExecStop=/usr/local/bin/s6100_platform.sh deinit
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/z9100/scripts/platform_sensors.py
+++ b/z9100/scripts/platform_sensors.py
@@ -14,7 +14,6 @@ import logging
 
 Z9100_MAX_FAN_TRAYS = 5
 Z9100_MAX_PSUS = 2
-S6100_MAX_IOMS = 4
 
 MAILBOX_DIR = "/sys/devices/platform/SMF.512/hwmon/hwmon1"
 
@@ -42,10 +41,10 @@ def get_pmc_register(reg_name):
 logging.basicConfig(level=logging.DEBUG)
 
 if (os.path.isdir(MAILBOX_DIR)):
-    print 'dell-s6100-lpc'
-    print 'Adapter: S6100 Platform Management Controller'
+    print 'dell-z9100-lpc'
+    print 'Adapter: Z9100 Platform Management Controller'
 else:
-    logging.error('S6100 Platform Management Controller module not loaded !')
+    logging.error('Z9100 Platform Management Controller module not loaded !')
     # sys.exit(0)
 
 # Print the information for temperature sensors

--- a/z9100/systemd/platform-modules-z9100.service
+++ b/z9100/systemd/platform-modules-z9100.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Dell Z9100 Platform modules
+Before=pmon.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/z9100_platform.sh init
+ExecStop=/usr/local/bin/z9100_platform.sh deinit
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This commit backports the fixes of depmod and systemd support
for s6100 and z9100 from master branch to 201807. Built the
SONiC binary loaded on both s6100 and z9100 checked the enumerations
of i2c drivers. Did ONIE install and sonic_installer of binaries
rebooted the units and checked.

Signed-off-by: Harish Venkatraman <Harish_Venkatraman@dell.com>